### PR TITLE
Impl for `TargetDataLayout` and `TargetTriple` for LLVM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
     # tidy-alphabetical-start
-    "compiler/tidec",
+    "compiler/tidec", "compiler/tidec_abi",
     "compiler/tidec_codegen_llvm",
     "compiler/tidec_lir",
     "compiler/tidec_utils",

--- a/README.md
+++ b/README.md
@@ -4,34 +4,43 @@
 
 - Y. Zhang, CGO'25 - [GoFree: Reducing Garbage Collection via Compiler-Inserted Freeing][GoFree: Reducing Garbage Collection via Compiler-Inserted Freeing]
 - M. Elsman, PLDI'24 - [Garbage-Collection Safety for Region-Based Type-Polymorphic Programs][Garbage-Collection Safety for Region-Based Type-Polymorphic Programs]
+- M. Elsman, PLDI'23 - [Parallelism in a Region Inference Context][Parallelism in a Region Inference Context]
 - C. Lattner, V. Adve, PLDI'05 - [Automatic Pool Allocation: Improving Performance by Controlling Data Structure Layout in the Heap][Automatic Pool Allocation: Improving Performance by Controlling Data Structure Layout in the Heap]
 - M. Rinard, PLDI'04 - [Region Inference for an Object-Oriented Language][Region Inference for an Object-Oriented Language]
 - C. Lattner, V. Adve, LCTES'03 - [Memory safety without runtime checks or garbage collection][Memory safety without runtime checks or garbage collection]
 - V. Adve, CASES'02 - [Ensuring code safety without runtime checks for real-time control systems][Ensuring code safety without runtime checks for real-time control systems]
 - C. Lattner, V. Adve, MPS'02 - [Automatic pool allocation for disjoint data structures][Automatic pool allocation for disjoint data structures]
 - C. Boyapati, PLDI'03 - [Ownership types for safe region-based memory management in real-time Java][Ownership types for safe region-based memory management in real-time Java]
+- N. Hallenberg, M. Elsman, M. Tofte, PLDI'02 - [Combining Region Inference and Garbage Collection][Combining Region Inference and Garbage Collection]
+- D. Grossman, PLDI'02 - [Region-based Memory Management in Cyclone][Region-based Memory Management in Cyclone]
 - A. Aiken, PLDI'01 - [Language support for regions][Language support for regions]
+- M. Montenegro, WFLP'01 - [A Simple Region Inference Algorithm for a First-Order Functional Language][A Simple Region Inference Algorithm for a First-Order Functional Language]
+- M. Tofte, TCS'01 - [A constraint-based region inference algorithm][A constraint-based region inference algorithm]
+- M. Tofte, TOPLAS'98 - [A Region Inference Algorithm][A Region Inference Algorithm]
+- M. Tofte, BOOK '97 - [Programming with Regions in the MLKit][Programming with Regions in the MLKit]
+- M. Tofte, J. Talpin, IaC'97 - [Region-based Memory Management][Region-based Memory Management]
 - A. Aiken, PLDI'95 - [Better Static Memory Management: Improving Region-Based Analysis of Higher-Order Languages][Better Static Memory Management: Improving Region-Based Analysis of Higher-Order Languages]
 - D. Barret, PLDI'93 - [Using lifetime predictors to improve memory allocation performance][Using lifetime predictors to improve memory allocation performance]
+- J. Talpin, JFP'92 - [Polymorphic type, region and effect inference][Polymorphic type, region and effect inference]
+
 
 [GoFree: Reducing Garbage Collection via Compiler-Inserted Freeing]: https://dl.acm.org/doi/pdf/10.1145/3696443.3708925
-
 [Garbage-Collection Safety for Region-Based Type-Polymorphic Programs]: https://dl.acm.org/doi/pdf/10.1145/3591229
-
+[Parallelism in a Region Inference Context]: https://dl.acm.org/doi/abs/10.1145/3591256
 [Automatic Pool Allocation: Improving Performance by Controlling Data Structure Layout in the Heap]: https://dl.acm.org/doi/pdf/10.1145/1064978.1065027
-
 [Region Inference for an Object-Oriented Language]: https://dl.acm.org/doi/pdf/10.1145/996893.996871
-
 [Memory safety without runtime checks or garbage collection]: https://dl.acm.org/doi/abs/10.1145/780732.780743
-
 [Ensuring code safety without runtime checks for real-time control systems]: https://dl.acm.org/doi/abs/10.1145/581630.581678
-
 [Automatic pool allocation for disjoint data structures]: https://dl.acm.org/doi/abs/10.1145/773146.773041
-
 [Ownership types for safe region-based memory management in real-time Java]: https://dl.acm.org/doi/abs/10.1145/781131.781168
-
+[Combining Region Inference and Garbage Collection]: https://dl.acm.org/doi/pdf/10.1145/512529.512547
+[Region-based Memory Management in Cyclone]: https://dl.acm.org/doi/pdf/10.1145/512529.512563
 [Language support for regions]:https://dl.acm.org/doi/abs/10.1145/378795.378815
-
+[A Simple Region Inference Algorithm for a First-Order Functional Language]: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=6ea31aa485f5b03704d0d450b487feb472700fbc#page=152
+[A constraint-based region inference algorithm]: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=a604aa98396eb882fe42247e7db2a77e2e79400c
+[A Region Inference Algorithm]: https://dl.acm.org/doi/pdf/10.1145/291891.291894
+[Programming with Regions in the MLKit]: https://www.researchgate.net/profile/Martin-Elsman-2/publication/357775683_Programming_with_Regions_in_the_MLKit_for_Version_460/links/61ded5f1034dda1b9ef188a4/Programming-with-Regions-in-the-MLKit-for-Version-460.pdf
+[Region-based Memory Management]: https://www.sciencedirect.com/science/article/pii/S0890540196926139
 [Better Static Memory Management: Improving Region-Based Analysis of Higher-Order Languages]: https://dl.acm.org/doi/pdf/10.1145/207110.207137
-
 [Using lifetime predictors to improve memory allocation performance]: https://dl.acm.org/doi/abs/10.1145/155090.155108
+[Polymorphic type, region and effect inference]: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=27d57f6be32bf2aded0c806026f60bb6bce1e813

--- a/compiler/tidec/Cargo.toml
+++ b/compiler/tidec/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 inkwell = { version = "0.5.0", features = ["llvm18-0"] } # inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0732f8dcb7b2b7f8edc25895d6dbd37ba439672c", features = [ "llvm19-1" ] }
+tidec_abi = { path = "../tidec_abi" }
 tidec_codegen_llvm = { path = "../tidec_codegen_llvm" }
+tidec_lir = { path = "../tidec_lir" }
 # tidy-alphabetical-end

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use inkwell::context::Context;
 use inkwell::types::BasicType;
-use inkwell::values::{BasicValueEnum, IntValue};
-use tidec_abi::{CodegenBackend, TargetDataLayout};
+use tidec_abi::CodegenBackend;
 use tidec_codegen_llvm::builder::CodegenBuilder;
 use tidec_codegen_llvm::context::CodegenCtx;
 use tidec_codegen_llvm::lir::types::BasicTypesUtils;
@@ -21,7 +20,7 @@ use tidec_lir::syntax::LirTy;
 // }
 // ```
 fn main() {
-    let lir_ctx = LirTyCtx::new(CodegenBackend::Llvm, TargetDataLayout::default());
+    let lir_ctx = LirTyCtx::new(CodegenBackend::Llvm);
 
     let context = Context::create();
     let module = context.create_module("main");

--- a/compiler/tidec_abi/Cargo.toml
+++ b/compiler/tidec_abi/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tidec_abi"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# tidy-alphabetical-start
+# tidy-alphabetical-end

--- a/compiler/tidec_abi/src/lib.rs
+++ b/compiler/tidec_abi/src/lib.rs
@@ -1,0 +1,185 @@
+pub enum CodegenBackend {
+    /// The LLVM backend.
+    Llvm,
+
+    /// The Cranelift backend.
+    Cranelift,
+}
+
+pub struct AbiSize(pub u64);
+pub struct AbiAlign(pub u64);
+
+pub enum Endianess {
+    /// Little-endian.
+    Little,
+
+    /// Big-endian.
+    Big,
+}
+
+pub struct TargetDataLayout {
+    pub endianess: Endianess,
+    pub i1_align: AbiAlign,
+    pub i8_align: AbiAlign,
+    pub i16_align: AbiAlign,
+    pub i32_align: AbiAlign,
+    pub i64_align: AbiAlign,
+    pub i128_align: AbiAlign,
+    pub f16_align: AbiAlign,
+    pub f32_align: AbiAlign,
+    pub f64_align: AbiAlign,
+    pub f128_align: AbiAlign,
+
+    /// The size of pointers in bytes.
+    pub pointer_size: u64,
+
+    pub pointer_align: AbiAlign,
+    pub aggregate_align: AbiAlign,
+
+    /// Alignments for vector types.
+    pub vector_align: Vec<(u64, AbiAlign)>,
+
+    /// An identifier that specifies the address space that some operation
+    /// should operate on. Special address spaces have an effect on code generation,
+    /// depending on the target and the address spaces it implements.
+    ///
+    /// When `0`, which is the default address space, corresponds to the data space.
+    pub instruction_address_space: u32,
+}
+
+impl Default for TargetDataLayout {
+    fn default() -> Self {
+        TargetDataLayout {
+            endianess: Endianess::Big,
+            i1_align: AbiAlign(8),
+            i8_align: AbiAlign(8),
+            i16_align: AbiAlign(16),
+            i32_align: AbiAlign(32),
+            i64_align: AbiAlign(32),
+            i128_align: AbiAlign(32),
+            f16_align: AbiAlign(16),
+            f32_align: AbiAlign(32),
+            f64_align: AbiAlign(64),
+            f128_align: AbiAlign(128),
+            pointer_size: 64,
+            pointer_align: AbiAlign(64),
+            aggregate_align: AbiAlign(0),
+            vector_align: vec![(64, AbiAlign(64)), (128, AbiAlign(128))],
+            instruction_address_space: 0,
+        }
+    }
+}
+
+pub struct TyAndLayout<T> {
+    pub ty: T,
+    pub size: AbiSize,
+    pub align: AbiAlign,
+}
+
+impl TargetDataLayout {
+    pub fn new(codegen_backend: CodegenBackend) -> Self {
+        match codegen_backend {
+            CodegenBackend::Llvm => todo!(),
+            CodegenBackend::Cranelift => unimplemented!(),
+        }
+    }
+
+    // /// Parse data layout from an [llvm data layout string](https://llvm.org/docs/LangRef.html#data-layout)
+    // pub fn parse_from_llvm_datalayout_string<'a>(
+    //     input: &'a str,
+    // ) -> Result<TargetDataLayout, TargetDataLayoutErrors<'a>> {
+    //     // Parse an address space index from a string.
+    //     let parse_address_space = |s: &'a str, cause: &'a str| {
+    //         s.parse::<u32>().map(AddressSpace).map_err(|err| {
+    //             TargetDataLayoutErrors::InvalidAddressSpace { addr_space: s, cause, err }
+    //         })
+    //     };
+    //
+    //     // Parse a bit count from a string.
+    //     let parse_bits = |s: &'a str, kind: &'a str, cause: &'a str| {
+    //         s.parse::<u64>().map_err(|err| TargetDataLayoutErrors::InvalidBits {
+    //             kind,
+    //             bit: s,
+    //             cause,
+    //             err,
+    //         })
+    //     };
+    //
+    //     // Parse a size string.
+    //     let parse_size =
+    //         |s: &'a str, cause: &'a str| parse_bits(s, "size", cause).map(Size::from_bits);
+    //
+    //     // Parse an alignment string.
+    //     let parse_align = |s: &[&'a str], cause: &'a str| {
+    //         if s.is_empty() {
+    //             return Err(TargetDataLayoutErrors::MissingAlignment { cause });
+    //         }
+    //         let align_from_bits = |bits| {
+    //             Align::from_bits(bits)
+    //                 .map_err(|err| TargetDataLayoutErrors::InvalidAlignment { cause, err })
+    //         };
+    //         let abi = parse_bits(s[0], "alignment", cause)?;
+    //         let pref = s.get(1).map_or(Ok(abi), |pref| parse_bits(pref, "alignment", cause))?;
+    //         Ok(AbiAndPrefAlign { abi: align_from_bits(abi)?, pref: align_from_bits(pref)? })
+    //     };
+    //
+    //     let mut dl = TargetDataLayout::default();
+    //     let mut i128_align_src = 64;
+    //     for spec in input.split('-') {
+    //         let spec_parts = spec.split(':').collect::<Vec<_>>();
+    //
+    //         match &*spec_parts {
+    //             ["e"] => dl.endian = Endian::Little,
+    //             ["E"] => dl.endian = Endian::Big,
+    //             [p] if p.starts_with('P') => {
+    //                 dl.instruction_address_space = parse_address_space(&p[1..], "P")?
+    //             }
+    //             ["a", a @ ..] => dl.aggregate_align = parse_align(a, "a")?,
+    //             ["f16", a @ ..] => dl.f16_align = parse_align(a, "f16")?,
+    //             ["f32", a @ ..] => dl.f32_align = parse_align(a, "f32")?,
+    //             ["f64", a @ ..] => dl.f64_align = parse_align(a, "f64")?,
+    //             ["f128", a @ ..] => dl.f128_align = parse_align(a, "f128")?,
+    //             // FIXME(erikdesjardins): we should be parsing nonzero address spaces
+    //             // this will require replacing TargetDataLayout::{pointer_size,pointer_align}
+    //             // with e.g. `fn pointer_size_in(AddressSpace)`
+    //             [p @ "p", s, a @ ..] | [p @ "p0", s, a @ ..] => {
+    //                 dl.pointer_size = parse_size(s, p)?;
+    //                 dl.pointer_align = parse_align(a, p)?;
+    //             }
+    //             [s, a @ ..] if s.starts_with('i') => {
+    //                 let Ok(bits) = s[1..].parse::<u64>() else {
+    //                     parse_size(&s[1..], "i")?; // For the user error.
+    //                     continue;
+    //                 };
+    //                 let a = parse_align(a, s)?;
+    //                 match bits {
+    //                     1 => dl.i1_align = a,
+    //                     8 => dl.i8_align = a,
+    //                     16 => dl.i16_align = a,
+    //                     32 => dl.i32_align = a,
+    //                     64 => dl.i64_align = a,
+    //                     _ => {}
+    //                 }
+    //                 if bits >= i128_align_src && bits <= 128 {
+    //                     // Default alignment for i128 is decided by taking the alignment of
+    //                     // largest-sized i{64..=128}.
+    //                     i128_align_src = bits;
+    //                     dl.i128_align = a;
+    //                 }
+    //             }
+    //             [s, a @ ..] if s.starts_with('v') => {
+    //                 let v_size = parse_size(&s[1..], "v")?;
+    //                 let a = parse_align(a, s)?;
+    //                 if let Some(v) = dl.vector_align.iter_mut().find(|v| v.0 == v_size) {
+    //                     v.1 = a;
+    //                     continue;
+    //                 }
+    //                 // No existing entry, add a new one.
+    //                 dl.vector_align.push((v_size, a));
+    //             }
+    //             _ => {} // Ignore everything else.
+    //         }
+    //     }
+    //     Ok(dl)
+    // }
+}

--- a/compiler/tidec_codegen_llvm/Cargo.toml
+++ b/compiler/tidec_codegen_llvm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 inkwell = { version = "0.5.0", features = ["llvm18-0"] } # inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0732f8dcb7b2b7f8edc25895d6dbd37ba439672c", features = [ "llvm19-1" ] }
+tidec_abi = { path = "../tidec_abi" }
 tidec_lir = { path = "../tidec_lir" }
 tidec_utils = { path = "../tidec_utils" }
 # tidy-alphabetical-end

--- a/compiler/tidec_codegen_llvm/src/builder.rs
+++ b/compiler/tidec_codegen_llvm/src/builder.rs
@@ -1,0 +1,72 @@
+use std::ops::Deref;
+
+use inkwell::context::Context;
+use inkwell::module::Module;
+use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FunctionType};
+use inkwell::values::{FunctionValue, IntValue};
+use inkwell::{basic_block::BasicBlock, builder::Builder};
+use tidec_abi::TyAndLayout;
+
+use crate::context::CodegenCtx;
+use crate::lir::types::BasicTypesUtils;
+use crate::BuilderMethods;
+use tidec_lir::lir::{LirBody, LirUnit};
+use tidec_lir::syntax::{LirTy, Local, LocalData, RETURN_PLACE};
+
+pub struct CodegenBuilder<'a, 'll> {
+    pub builder: Builder<'ll>,
+    pub ctx: &'a CodegenCtx<'ll>,
+}
+
+impl<'ll> Deref for CodegenBuilder<'_, 'll> {
+    type Target = CodegenCtx<'ll>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ctx
+    }
+}
+
+impl<'a, 'll> CodegenBuilder<'a, 'll> {
+    pub fn with_ctx(ctx: &'a CodegenCtx<'ll>) -> Self {
+        let builder = ctx.ll_context.create_builder();
+        CodegenBuilder { builder, ctx }
+    }
+
+    pub fn llvm_layout_of(&self, ty: LirTy) -> Result<TyAndLayout<LirTy>, String> {
+        let size = ty.into_basic_type(self.ctx).size_of();
+        // let align = ty.into_basic_type(self.ctx).get
+
+        Err("tmp".to_string())
+    }
+}
+
+impl<'a, 'll> BuilderMethods<'a, 'll> for CodegenBuilder<'a, 'll> {
+    type CodegenCtx = CodegenCtx<'ll>;
+
+    /// Create a new CodeGenBuilder from a CodeGenCtx and a BasicBlock.
+    /// The builder is positioned at the end of the BasicBlock.
+    fn build(ctx: &'a Self::CodegenCtx, llbb: BasicBlock) -> Self {
+        let builder = CodegenBuilder::with_ctx(ctx);
+        builder.builder.position_at_end(llbb);
+        builder
+    }
+
+    /// Append a new basic block to the function.
+    fn append_basic_block(
+        ctx: &Self::CodegenCtx,
+        fn_value: FunctionValue<'ll>,
+        name: &str,
+    ) -> BasicBlock<'ll> {
+        ctx.ll_context.append_basic_block(fn_value, name)
+    }
+
+    fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy> {
+        match self.llvm_layout_of(ty) {
+            Ok(layout) => layout,
+            Err(err) => {
+                // Fallback to the LIR type context
+                self.lir_ty_ctx.layout_of(ty)
+            }
+        }
+    }
+}

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -1,0 +1,88 @@
+use std::ops::Deref;
+
+use inkwell::context::Context;
+use inkwell::module::Module;
+use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
+use inkwell::values::FunctionValue;
+use inkwell::{basic_block::BasicBlock, builder::Builder};
+
+use crate::lir::types::BasicTypesUtils;
+use crate::CodegenMethods;
+use tidec_lir::lir::{LirBody, LirTyCtx, LirUnit};
+use tidec_lir::syntax::{LirTy, Local, LocalData, RETURN_PLACE};
+use tidec_utils::index_vec::IdxVec;
+
+pub struct CodegenCtx<'ll> {
+    // FIXME: Make this private
+    pub ll_context: &'ll Context,
+    pub ll_module: Module<'ll>,
+
+    pub lir_ty_ctx: LirTyCtx,
+    // TODO: Add filelds from rustc/compiler/rustc_codegen_llvm/src/context.rs
+}
+
+impl<'ll> Deref for CodegenCtx<'ll> {
+    type Target = Context;
+
+    fn deref(&self) -> &Self::Target {
+        self.ll_context
+    }
+}
+
+impl<'ll> CodegenCtx<'ll> {
+    fn declare_fn(
+        &self,
+        ret_ty: BasicTypeEnum<'ll>,
+        param_tys: &[BasicMetadataTypeEnum<'ll>],
+    ) -> FunctionType<'ll> {
+        let fn_ty = match ret_ty {
+            BasicTypeEnum::IntType(int_type) => int_type.fn_type(param_tys, false),
+            BasicTypeEnum::ArrayType(array_type) => array_type.fn_type(param_tys, false),
+            BasicTypeEnum::FloatType(float_type) => float_type.fn_type(param_tys, false),
+            BasicTypeEnum::PointerType(pointer_type) => pointer_type.fn_type(param_tys, false),
+            BasicTypeEnum::StructType(struct_type) => struct_type.fn_type(param_tys, false),
+            BasicTypeEnum::VectorType(vector_type) => vector_type.fn_type(param_tys, false),
+        };
+
+        fn_ty
+    }
+}
+
+impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
+    fn new(
+        lir_ty_ctx: LirTyCtx,
+        ll_context: &'ll Context,
+        ll_module: Module<'ll>,
+    ) -> CodegenCtx<'ll> {
+        CodegenCtx {
+            ll_context,
+            ll_module,
+            lir_ty_ctx,
+        }
+    }
+
+    fn get_fn(&self, name: &str) -> Option<FunctionValue<'ll>> {
+        self.ll_module.get_function(name)
+    }
+
+    fn new_fn(&self, lir_body: &LirBody) -> FunctionValue<'ll> {
+        let name = lir_body.metadata.name.as_str();
+
+        if let Some(f) = self.get_fn(name) {
+            return f;
+        }
+
+        let ret_ty = lir_body.ret_and_args[RETURN_PLACE]
+            .ty
+            .into_basic_type(&self);
+        let formal_param_tys = lir_body.ret_and_args.as_slice()[RETURN_PLACE..]
+            .iter()
+            .map(|local_data| local_data.ty.into_basic_type_metadata(&self))
+            .collect::<Vec<_>>();
+
+        let fn_ty = self.declare_fn(ret_ty, formal_param_tys.as_slice());
+        let fn_val = self.ll_module.add_function(name, fn_ty, None);
+
+        fn_val
+    }
+}

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 
 use inkwell::context::Context;
+use inkwell::data_layout::DataLayout;
 use inkwell::module::Module;
+use inkwell::targets::TargetTriple;
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
 use inkwell::values::FunctionValue;
 use inkwell::{basic_block::BasicBlock, builder::Builder};
@@ -54,6 +56,13 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
         ll_context: &'ll Context,
         ll_module: Module<'ll>,
     ) -> CodegenCtx<'ll> {
+        let target = lir_ty_ctx.target();
+        let data_layout_string = target.data_layout_string();
+        let target_triple_string = target.target_triple_string();
+
+        ll_module.set_triple(&TargetTriple::create(&target_triple_string));
+        // ll_module.set_data_layout(&DataLayout::create(&data_layout_string));
+
         CodegenCtx {
             ll_context,
             ll_module,

--- a/compiler/tidec_codegen_llvm/src/lir/types.rs
+++ b/compiler/tidec_codegen_llvm/src/lir/types.rs
@@ -1,31 +1,25 @@
-use crate::CodeGenCtx;
+use crate::CodegenCtx;
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum};
 use tidec_lir::syntax::LirTy;
 
-pub trait IntoBasicTypeMetadata<'ll> {
-    fn into_basic_type_metadata(self, ctx: &CodeGenCtx<'ll>) -> BasicMetadataTypeEnum<'ll>;
+pub trait BasicTypesUtils<'ll> {
+    fn into_basic_type_metadata(self, ctx: &CodegenCtx<'ll>) -> BasicMetadataTypeEnum<'ll>;
+    fn into_basic_type(self, ctx: &CodegenCtx<'ll>) -> BasicTypeEnum<'ll>;
 }
 
-pub trait IntoBasicType<'ll> {
-    fn into_basic_type(self, ctx: &CodeGenCtx<'ll>) -> BasicTypeEnum<'ll>;
-}
-
-impl<'ll> IntoBasicTypeMetadata<'ll> for LirTy {
-    fn into_basic_type_metadata(self, ctx: &CodeGenCtx<'ll>) -> BasicMetadataTypeEnum<'ll> {
+impl<'ll> BasicTypesUtils<'ll> for LirTy {
+    fn into_basic_type_metadata(self, ctx: &CodegenCtx<'ll>) -> BasicMetadataTypeEnum<'ll> {
         match self {
             LirTy::I8 => BasicTypeEnum::IntType(ctx.ll_context.i8_type()).into(),
             LirTy::I16 => BasicTypeEnum::IntType(ctx.ll_context.i16_type()).into(),
             LirTy::I32 => BasicTypeEnum::IntType(ctx.ll_context.i32_type()).into(),
             LirTy::I64 => BasicTypeEnum::IntType(ctx.ll_context.i64_type()).into(),
             LirTy::I128 => BasicTypeEnum::IntType(ctx.ll_context.i128_type()).into(),
-
             LirTy::Metadata => BasicMetadataTypeEnum::MetadataType(ctx.ll_context.metadata_type()),
         }
     }
-}
 
-impl<'ll> IntoBasicType<'ll> for LirTy {
-    fn into_basic_type(self, ctx: &CodeGenCtx<'ll>) -> BasicTypeEnum<'ll> {
+    fn into_basic_type(self, ctx: &CodegenCtx<'ll>) -> BasicTypeEnum<'ll> {
         match self {
             LirTy::I8 => BasicTypeEnum::IntType(ctx.ll_context.i8_type()),
             LirTy::I16 => BasicTypeEnum::IntType(ctx.ll_context.i16_type()),

--- a/compiler/tidec_lir/Cargo.toml
+++ b/compiler/tidec_lir/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
+tidec_abi = { path = "../tidec_abi" }
 tidec_utils = { path = "../tidec_utils" }
 # tidy-alphabetical-end

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -1,30 +1,28 @@
+use crate::{
+    basic_blocks::{BasicBlock, BasicBlockData},
+    syntax::{Body, LirTy, Local, LocalData},
+};
+use tidec_abi::{CodegenBackend, TargetDataLayout, TyAndLayout};
 use tidec_utils::index_vec::IdxVec;
-use crate::{basic_blocks::{BasicBlock, BasicBlockData}, syntax::{Local, LocalData}};
 
 #[derive(Eq, PartialEq)]
 pub struct DefId(usize);
 
-/// The metadata of a module.
-pub struct Metadata {
-    pub module_name: String,
-}
-
-pub struct LirMetadata {
+pub struct LirBodyMetadata {
     /// The name of the function.
     pub name: String,
 
     /// The definition ID of the function.
     pub id: DefId,
-
 }
 
 /// The body of a function in LIR (Low-level Intermediate Representation).
 pub struct LirBody {
     /// The metadata of the function.
-    pub metadata: LirMetadata,
+    pub metadata: LirBodyMetadata,
 
     /// The locals for return value and arguments of the function.
-    pub ret_args: IdxVec<Local, LocalData>,
+    pub ret_and_args: IdxVec<Local, LocalData>,
 
     /// The rest of the locals.
     pub locals: IdxVec<Local, LocalData>,
@@ -33,3 +31,37 @@ pub struct LirBody {
     pub basic_blocks: IdxVec<BasicBlock, BasicBlockData>,
 }
 
+/// The metadata of a LIR unit (module).
+pub struct LirUnitMetadata {
+    pub unit_name: String,
+}
+
+/// The LIR unit (module).
+pub struct LirUnit {
+    /// The metadata of the unit.
+    pub metadata: LirUnitMetadata,
+
+    /// The functions in the unit.
+    pub body: IdxVec<Body, LirBody>,
+}
+
+pub struct LirTyCtx {
+    codegen_backend: CodegenBackend,
+
+    /// The target data layout.
+    target_data_layout: TargetDataLayout,
+}
+
+impl LirTyCtx {
+    /// Create a new LIR type context.
+    pub fn new(codegen_backend: CodegenBackend, target_data_layout: TargetDataLayout) -> Self {
+        LirTyCtx {
+            codegen_backend,
+            target_data_layout,
+        }
+    }
+
+    pub fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy> {
+        todo!()
+    }
+}

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -2,7 +2,7 @@ use crate::{
     basic_blocks::{BasicBlock, BasicBlockData},
     syntax::{Body, LirTy, Local, LocalData},
 };
-use tidec_abi::{CodegenBackend, TargetDataLayout, TyAndLayout};
+use tidec_abi::{CodegenBackend, Target, TargetDataLayout, TyAndLayout};
 use tidec_utils::index_vec::IdxVec;
 
 #[derive(Eq, PartialEq)]
@@ -46,19 +46,17 @@ pub struct LirUnit {
 }
 
 pub struct LirTyCtx {
-    codegen_backend: CodegenBackend,
-
-    /// The target data layout.
-    target_data_layout: TargetDataLayout,
+    target: Target,
 }
 
 impl LirTyCtx {
-    /// Create a new LIR type context.
-    pub fn new(codegen_backend: CodegenBackend, target_data_layout: TargetDataLayout) -> Self {
-        LirTyCtx {
-            codegen_backend,
-            target_data_layout,
-        }
+    pub fn new(codegen_backend: CodegenBackend) -> Self {
+        let target = Target::new(codegen_backend);
+        LirTyCtx { target }
+    }
+
+    pub fn target(&self) -> &Target {
+        &self.target
     }
 
     pub fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy> {

--- a/compiler/tidec_lir/src/syntax.rs
+++ b/compiler/tidec_lir/src/syntax.rs
@@ -15,6 +15,9 @@ pub enum LirTy {
 #[derive(Eq, PartialEq)]
 pub struct Local(usize);
 
+#[derive(Eq, PartialEq)]
+pub struct Body(usize);
+
 pub const RETURN_PLACE: Local = Local(0);
 
 pub(crate) enum RValue {
@@ -24,6 +27,7 @@ pub(crate) enum RValue {
 #[derive(Copy, Clone)]
 pub struct LocalData {
     pub ty: LirTy,
+    pub mutable: bool,
 }
 
 /// A statement in a basic block.
@@ -52,6 +56,24 @@ pub(crate) enum Terminator {
 impl Idx for Local {
     fn new(idx: usize) -> Self {
         Local(idx)
+    }
+
+    fn idx(&self) -> usize {
+        self.0
+    }
+
+    fn incr(&mut self) {
+        self.0 += 1;
+    }
+
+    fn incr_by(&mut self, by: usize) {
+        self.0 += by;
+    }
+}
+
+impl Idx for Body {
+    fn new(idx: usize) -> Self {
+        Body(idx)
     }
 
     fn idx(&self) -> usize {

--- a/compiler/tidec_utils/src/index_slice.rs
+++ b/compiler/tidec_utils/src/index_slice.rs
@@ -9,7 +9,6 @@ use std::{
     slice::{self, SliceIndex},
 };
 
-
 /// A view into contiguous `T`s, indexed by `I` rather than by `usize`.
 ///
 /// One common pattern you'll see is code that uses [`IdxVec::from_elem`]


### PR DESCRIPTION
# Summary

1. Additional links for region-based papers
2. ABI: `TargetDataLayout` and `TargetTriple` to pass to LLVM