### PR TITLE
ABI: Pass to LLVM the parsed `tidec` TargetDataLayout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+1. Separate documentation for `TIDEC_LOG` usage with filters
+2. Add tests
+3. Implement a derive macro for deriving spans for a struct
+

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -53,20 +53,23 @@ fn main() {
     let deref_0 = codegen.builder.build_load(i32_type, _0, "_0").unwrap();
     codegen.builder.build_return(Some(&deref_0)).unwrap();
 
-    // BEGIN TEST ===================
-    let int_value = LirTy::I8.into_basic_type(codegen.ctx).size_of().unwrap();
-    let align = int_value.get_type().get_alignment();
-    println!("Size of i8: {}", int_value);
-    println!("Alignment of i8: {}", align);
-
-    // END   TEST ===================
-
     codegen
         .ctx
         .ll_module
         .print_to_file(Path::new("main.ll"))
         .unwrap();
     // module.print_to_stderr();
+
+
+    // =========================
+    // ========= TESTS =========
+    // =========================
+
+    let int_value = LirTy::I8.into_basic_type(codegen.ctx).size_of().unwrap();
+    let align = int_value.get_type().get_alignment();
+    println!("Size of i8: {}", int_value);
+    println!("Alignment of i8: {}", align);
+
 }
 
 /// Initialize the logger for the tidec project.

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -8,7 +8,7 @@ use tidec_abi::CodegenBackend;
 use tidec_codegen_llvm::builder::CodegenBuilder;
 use tidec_codegen_llvm::context::CodegenCtx;
 use tidec_codegen_llvm::lir::types::BasicTypesUtils;
-use tidec_codegen_llvm::CodegenMethods;
+use tidec_codegen_llvm::traits::CodegenMethods;
 use tidec_lir::lir::LirTyCtx;
 use tidec_lir::syntax::LirTy;
 use tidec_utils::v_debug;
@@ -60,7 +60,6 @@ fn main() {
         .unwrap();
     // module.print_to_stderr();
 
-
     // =========================
     // ========= TESTS =========
     // =========================
@@ -69,7 +68,6 @@ fn main() {
     let align = int_value.get_type().get_alignment();
     println!("Size of i8: {}", int_value);
     println!("Alignment of i8: {}", align);
-
 }
 
 /// Initialize the logger for the tidec project.

--- a/compiler/tidec_abi/Cargo.toml
+++ b/compiler/tidec_abi/Cargo.toml
@@ -5,4 +5,6 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
+tracing = "0.1.41"
 # tidy-alphabetical-end
+

--- a/compiler/tidec_abi/src/lib.rs
+++ b/compiler/tidec_abi/src/lib.rs
@@ -369,6 +369,7 @@ impl TargetTriple {
         }
     }
 
+    // ARCHITECTURE-VENDOR-OPERATING_SYSTEM-ENVIRONMENT
     pub fn into_llvm_triple_string(&self) -> String {
         format!(
             "{}-{}-{}-{}-{}",
@@ -389,8 +390,9 @@ pub struct TyAndLayout<T> {
 
 #[derive(Debug)]
 pub struct Target {
-    pub data_layout: TargetDataLayout,
     pub codegen_backend: CodegenBackend,
+
+    pub data_layout: TargetDataLayout,
 
     /// If unspecified, the target triple will be not setted
     /// in the LLVM module.

--- a/compiler/tidec_codegen_llvm/Cargo.toml
+++ b/compiler/tidec_codegen_llvm/Cargo.toml
@@ -10,6 +10,5 @@ tidec_abi = { path = "../tidec_abi" }
 tidec_lir = { path = "../tidec_lir" }
 tidec_utils = { path = "../tidec_utils" }
 tracing = "0.1.41"
-tracing-attributes = "0.1.28"
 # tidy-alphabetical-end
 

--- a/compiler/tidec_codegen_llvm/Cargo.toml
+++ b/compiler/tidec_codegen_llvm/Cargo.toml
@@ -9,5 +9,7 @@ inkwell = { version = "0.5.0", features = ["llvm18-0"] } # inkwell = { git = "ht
 tidec_abi = { path = "../tidec_abi" }
 tidec_lir = { path = "../tidec_lir" }
 tidec_utils = { path = "../tidec_utils" }
+tracing = "0.1.41"
+tracing-attributes = "0.1.28"
 # tidy-alphabetical-end
 

--- a/compiler/tidec_codegen_llvm/src/builder.rs
+++ b/compiler/tidec_codegen_llvm/src/builder.rs
@@ -6,6 +6,7 @@ use inkwell::types::{BasicMetadataTypeEnum, BasicType, BasicTypeEnum, FunctionTy
 use inkwell::values::{FunctionValue, IntValue};
 use inkwell::{basic_block::BasicBlock, builder::Builder};
 use tidec_abi::TyAndLayout;
+use tracing::instrument;
 
 use crate::context::CodegenCtx;
 use crate::lir::types::BasicTypesUtils;
@@ -13,6 +14,10 @@ use crate::BuilderMethods;
 use tidec_lir::lir::{LirBody, LirUnit};
 use tidec_lir::syntax::{LirTy, Local, LocalData, RETURN_PLACE};
 
+/// A builder for generating LLVM IR code.
+///
+/// This struct wraps the `inkwell::builder::Builder` and provides
+/// additional methods for code generation.
 pub struct CodegenBuilder<'a, 'll> {
     pub builder: Builder<'ll>,
     pub ctx: &'a CodegenCtx<'ll>,
@@ -27,6 +32,7 @@ impl<'ll> Deref for CodegenBuilder<'_, 'll> {
 }
 
 impl<'a, 'll> CodegenBuilder<'a, 'll> {
+    #[instrument(skip(ctx))]
     pub fn with_ctx(ctx: &'a CodegenCtx<'ll>) -> Self {
         let builder = ctx.ll_context.create_builder();
         CodegenBuilder { builder, ctx }

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -3,10 +3,11 @@ use std::ops::Deref;
 use inkwell::context::Context;
 use inkwell::data_layout::DataLayout;
 use inkwell::module::Module;
-use inkwell::targets::TargetTriple;
+use inkwell::targets::{TargetData, TargetTriple};
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
 use inkwell::values::FunctionValue;
 use inkwell::{basic_block::BasicBlock, builder::Builder};
+use tracing::instrument;
 
 use crate::lir::types::BasicTypesUtils;
 use crate::CodegenMethods;
@@ -51,6 +52,7 @@ impl<'ll> CodegenCtx<'ll> {
 }
 
 impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
+    #[instrument(skip(lir_ty_ctx, ll_context, ll_module))]
     fn new(
         lir_ty_ctx: LirTyCtx,
         ll_context: &'ll Context,
@@ -61,7 +63,8 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
         let target_triple_string = target.target_triple_string();
 
         ll_module.set_triple(&TargetTriple::create(&target_triple_string));
-        // ll_module.set_data_layout(&DataLayout::create(&data_layout_string));
+        // TODO: TargetData contains methods to know the size, align, etc... for each LLVM type
+        ll_module.set_data_layout(&TargetData::create(&data_layout_string).get_data_layout());
 
         CodegenCtx {
             ll_context,

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -1,19 +1,16 @@
 use std::ops::Deref;
 
 use inkwell::context::Context;
-use inkwell::data_layout::DataLayout;
 use inkwell::module::Module;
 use inkwell::targets::{TargetData, TargetTriple};
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
 use inkwell::values::FunctionValue;
-use inkwell::{basic_block::BasicBlock, builder::Builder};
 use tracing::instrument;
 
 use crate::lir::types::BasicTypesUtils;
 use crate::CodegenMethods;
-use tidec_lir::lir::{LirBody, LirTyCtx, LirUnit};
-use tidec_lir::syntax::{LirTy, Local, LocalData, RETURN_PLACE};
-use tidec_utils::index_vec::IdxVec;
+use tidec_lir::lir::{LirBody, LirTyCtx};
+use tidec_lir::syntax::RETURN_PLACE;
 
 pub struct CodegenCtx<'ll> {
     // FIXME: Make this private
@@ -63,7 +60,8 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
         let target_triple_string = target.target_triple_string();
 
         ll_module.set_triple(&TargetTriple::create(&target_triple_string));
-        // TODO: TargetData contains methods to know the size, align, etc... for each LLVM type
+        // TODO: As TargetData contains methods to know the size, align, etc... for each LLVM type
+        // we could consider to store it in a context
         ll_module.set_data_layout(&TargetData::create(&data_layout_string).get_data_layout());
 
         CodegenCtx {

--- a/compiler/tidec_codegen_llvm/src/traits.rs
+++ b/compiler/tidec_codegen_llvm/src/traits.rs
@@ -1,0 +1,32 @@
+use inkwell::basic_block::BasicBlock;
+use inkwell::context::Context;
+use inkwell::module::Module;
+use inkwell::values::FunctionValue;
+
+use tidec_abi::TyAndLayout;
+use tidec_lir::lir::{LirBody, LirTyCtx};
+use tidec_lir::syntax::LirTy;
+
+// TODO: This trait should be generic over the LLVM backend.
+pub trait CodegenMethods<'ll> {
+    fn new(lir_ty_ctx: LirTyCtx, ll_context: &'ll Context, ll_module: Module<'ll>) -> Self;
+    fn get_fn(&self, name: &str) -> Option<FunctionValue<'ll>>;
+    fn new_fn(&self, lir_body: &LirBody) -> FunctionValue<'ll>;
+}
+
+// =================
+
+// TODO: Make CodegenMethods generic (not LLVM specific)
+pub trait BuilderMethods<'a, 'll> {
+    type CodegenCtx: CodegenMethods<'ll>;
+
+    fn build(ctx: &'a Self::CodegenCtx, llbb: BasicBlock) -> Self;
+
+    fn append_basic_block(
+        ctx: &Self::CodegenCtx,
+        fn_value: FunctionValue<'ll>, // TODO: Make FunctionValue generic
+        name: &str,
+    ) -> BasicBlock<'ll>;
+
+    fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy>;
+}

--- a/compiler/tidec_lir/Cargo.toml
+++ b/compiler/tidec_lir/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 tidec_abi = { path = "../tidec_abi" }
 tidec_utils = { path = "../tidec_utils" }
 tracing = "0.1.41"
-tracing-attributes = "0.1.28"
 # tidy-alphabetical-end

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -2,8 +2,8 @@ use crate::{
     basic_blocks::{BasicBlock, BasicBlockData},
     syntax::{Body, LirTy, Local, LocalData},
 };
-use tidec_abi::{CodegenBackend, Target, TargetDataLayout, TyAndLayout};
-use tidec_utils::{index_vec::IdxVec, v_debug};
+use tidec_abi::{CodegenBackend, Target, TyAndLayout};
+use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, instrument};
 
 #[derive(Eq, PartialEq)]

--- a/compiler/tidec_log/src/lib.rs
+++ b/compiler/tidec_log/src/lib.rs
@@ -55,7 +55,11 @@
 use std::{env::VarError, fs::File, io::IsTerminal, path::PathBuf};
 use tracing::Subscriber;
 use tracing_subscriber::{
-    fmt::{format::FmtSpan, layer}, prelude::*, registry::LookupSpan, util::TryInitError, EnvFilter, Layer
+    EnvFilter, Layer,
+    fmt::{format::FmtSpan, layer},
+    prelude::*,
+    registry::LookupSpan,
+    util::TryInitError,
 };
 
 /// The ZST (zero-sized type) for the logger.
@@ -195,7 +199,7 @@ impl Logger {
         for<'a> S: LookupSpan<'a>,
     {
         let layer = layer()
-            .with_span_events(FmtSpan::FULL)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE) // FmtSpan::FULL
             .with_ansi(color_log)
             .with_target(true)
             .with_line_number(line_numbers);


### PR DESCRIPTION
# Summary 

1. Retrieve and store LLVMDataLayout from `LirCxt`
2. Use `bytes` instead of `bits` for LLVM types (alignment and size)