### PR TITLE
`Linkage`, `Visibility`, `CallConv`, and `fn` preallocation LLVM side

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     # tidy-alphabetical-start
     "compiler/tidec",
     "compiler/tidec_abi",
-    "compiler/tidec_codegen_llvm",
+    "compiler/tidec_codegen_llvm", "compiler/tidec_codegen_ssa",
     "compiler/tidec_lir",
     "compiler/tidec_log",
     "compiler/tidec_utils",

--- a/compiler/tidec/Cargo.toml
+++ b/compiler/tidec/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 inkwell = { version = "0.5.0", features = ["llvm18-0"] } # inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0732f8dcb7b2b7f8edc25895d6dbd37ba439672c", features = [ "llvm19-1" ] }
 tidec_abi = { path = "../tidec_abi" }
 tidec_codegen_llvm = { path = "../tidec_codegen_llvm" }
+tidec_codegen_ssa = { path = "../tidec_codegen_ssa" }
 tidec_lir = { path = "../tidec_lir" }
 tidec_log = { path = "../tidec_log" }
 tidec_utils = { path = "../tidec_utils" }

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 
 use inkwell::context::Context;
 use inkwell::types::BasicType;
-use tidec_abi::CodegenBackend;
+use tidec_abi::BackendKind;
 use tidec_codegen_llvm::builder::CodegenBuilder;
 use tidec_codegen_llvm::context::CodegenCtx;
 use tidec_codegen_llvm::lir::lir_ty::BasicTypesUtils;
-use tidec_codegen_llvm::ssa::CodegenMethods;
+use tidec_codegen_ssa::traits::CodegenMethods;
 use tidec_lir::lir::LirTyCtx;
 use tidec_lir::syntax::LirTy;
 use tidec_utils::v_debug;
@@ -26,7 +26,7 @@ fn main() {
     init_tidec_logger();
     v_debug!("Logging initialized");
 
-    let lir_ctx = LirTyCtx::new(CodegenBackend::Llvm);
+    let lir_ctx = LirTyCtx::new(BackendKind::Llvm);
 
     let context = Context::create();
     let module = context.create_module("main");

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -7,7 +7,7 @@ use inkwell::types::BasicType;
 use tidec_abi::CodegenBackend;
 use tidec_codegen_llvm::builder::CodegenBuilder;
 use tidec_codegen_llvm::context::CodegenCtx;
-use tidec_codegen_llvm::lir::types::BasicTypesUtils;
+use tidec_codegen_llvm::lir::lir_ty::BasicTypesUtils;
 use tidec_codegen_llvm::ssa::CodegenMethods;
 use tidec_lir::lir::LirTyCtx;
 use tidec_lir::syntax::LirTy;

--- a/compiler/tidec_abi/src/lib.rs
+++ b/compiler/tidec_abi/src/lib.rs
@@ -1,7 +1,7 @@
 use tracing::{info, instrument};
 
 #[derive(Debug)]
-pub enum CodegenBackend {
+pub enum BackendKind {
     /// The LLVM backend.
     Llvm,
 
@@ -402,7 +402,7 @@ pub struct TyAndLayout<T> {
 
 #[derive(Debug)]
 pub struct Target {
-    pub codegen_backend: CodegenBackend,
+    pub codegen_backend: BackendKind,
 
     pub data_layout: TargetDataLayout,
 
@@ -412,7 +412,7 @@ pub struct Target {
 }
 
 impl Target {
-    pub fn new(codegen_backend: CodegenBackend) -> Self {
+    pub fn new(codegen_backend: BackendKind) -> Self {
         Target {
             data_layout: TargetDataLayout::new(),
             codegen_backend,
@@ -424,8 +424,8 @@ impl Target {
     // compiler backend.
     pub fn data_layout_string(&self) -> String {
         match self.codegen_backend {
-            CodegenBackend::Llvm => self.data_layout.into_llvm_datalayout_string(),
-            CodegenBackend::Cranelift => self.data_layout.into_cranelift_datalayout_string(),
+            BackendKind::Llvm => self.data_layout.into_llvm_datalayout_string(),
+            BackendKind::Cranelift => self.data_layout.into_cranelift_datalayout_string(),
         }
     }
 
@@ -437,12 +437,12 @@ impl Target {
         }
 
         match self.codegen_backend {
-            CodegenBackend::Llvm => self
+            BackendKind::Llvm => self
                 .target_triple
                 .as_ref()
                 .unwrap()
                 .into_llvm_triple_string(),
-            CodegenBackend::Cranelift => self
+            BackendKind::Cranelift => self
                 .target_triple
                 .as_ref()
                 .unwrap()

--- a/compiler/tidec_codegen_llvm/Cargo.toml
+++ b/compiler/tidec_codegen_llvm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # tidy-alphabetical-start
 inkwell = { version = "0.5.0", features = ["llvm18-0"] } # inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0732f8dcb7b2b7f8edc25895d6dbd37ba439672c", features = [ "llvm19-1" ] }
 tidec_abi = { path = "../tidec_abi" }
+tidec_codegen_ssa = { path = "../tidec_codegen_ssa" }
 tidec_lir = { path = "../tidec_lir" }
 tidec_utils = { path = "../tidec_utils" }
 tracing = "0.1.41"

--- a/compiler/tidec_codegen_llvm/src/builder.rs
+++ b/compiler/tidec_codegen_llvm/src/builder.rs
@@ -8,7 +8,7 @@ use tidec_lir::syntax::LirTy;
 use tracing::instrument;
 
 use crate::context::CodegenCtx;
-use crate::lir::types::BasicTypesUtils;
+use crate::lir::lir_ty::BasicTypesUtils;
 use crate::ssa::CodegenBackendTypes;
 use crate::BuilderMethods;
 

--- a/compiler/tidec_codegen_llvm/src/builder.rs
+++ b/compiler/tidec_codegen_llvm/src/builder.rs
@@ -4,13 +4,14 @@ use inkwell::types::BasicType;
 use inkwell::values::{AnyValueEnum, FunctionValue};
 use inkwell::{basic_block::BasicBlock, builder::Builder};
 use tidec_abi::TyAndLayout;
+use tidec_codegen_ssa::traits::{
+    BuilderMethods, CodegenBackend, CodegenBackendTypes, CodegenMethods, PreDefineCodegenMethods,
+};
 use tidec_lir::syntax::LirTy;
 use tracing::instrument;
 
 use crate::context::CodegenCtx;
 use crate::lir::lir_ty::BasicTypesUtils;
-use crate::ssa::CodegenBackendTypes;
-use crate::BuilderMethods;
 
 /// A builder for generating LLVM IR code.
 ///

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 
 use inkwell::basic_block::BasicBlock;
 use inkwell::context::Context;
-use inkwell::module::{Linkage, Module};
+use inkwell::module::Module;
 use inkwell::targets::{TargetData, TargetTriple};
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum, FunctionType};
 use inkwell::values::{AnyValueEnum, BasicMetadataValueEnum};
@@ -14,8 +14,9 @@ use crate::lir::lir_body_metadata::{
     CallConvUtils, LinkageUtils, UnnamedAddressUtils, VisibilityUtils,
 };
 use crate::lir::lir_ty::BasicTypesUtils;
-use crate::ssa::{CodegenBackend, CodegenBackendTypes, PreDefineCodegenMethods};
-use crate::CodegenMethods;
+use tidec_codegen_ssa::traits::{
+    CodegenBackend, CodegenBackendTypes, CodegenMethods, PreDefineCodegenMethods,
+};
 use tidec_lir::lir::{DefId, LirBody, LirTyCtx};
 use tidec_lir::syntax::RETURN_PLACE;
 

--- a/compiler/tidec_codegen_llvm/src/lib.rs
+++ b/compiler/tidec_codegen_llvm/src/lib.rs
@@ -7,7 +7,8 @@ use builder::CodegenBuilder;
 use context::CodegenCtx;
 use inkwell::context::Context;
 
-use ssa::{compile_lir_unit, BuilderMethods, CodegenMethods};
+use ssa::compile_lir_unit;
+use tidec_codegen_ssa::traits::CodegenMethods;
 use tidec_lir::lir::{LirTyCtx, LirUnit};
 
 fn compile_codegen_unit<'ll>(lir_ty_ctx: LirTyCtx, lir_unit: LirUnit) {

--- a/compiler/tidec_codegen_llvm/src/lir/lir_body_metadata.rs
+++ b/compiler/tidec_codegen_llvm/src/lir/lir_body_metadata.rs
@@ -1,0 +1,78 @@
+use inkwell::{module::Linkage, values::UnnamedAddress, GlobalVisibility};
+use tidec_lir::lir;
+
+/// A trait to convert LirLinkage into LLVM Linkage.
+///
+/// We need to do this due to the orphan rule in Rust. This could cause the
+/// stop of the compilation process of an external crate.
+pub trait LinkageUtils {
+    fn into_linkage(&self) -> Linkage;
+}
+
+/// A trait to convert LirVisibility into LLVM Visibility (GlobalVisibility).
+///
+/// We need to do this due to the orphan rule in Rust. This could cause the
+/// stop of the compilation process of an external crate.
+pub trait VisibilityUtils {
+    fn into_visibility(&self) -> GlobalVisibility;
+}
+
+/// A trait to convert LirCallConv into LLVM CallConv (u32).
+///
+/// We need to do this due to the orphan rule in Rust. This could cause the
+/// stop of the compilation process of an external crate.
+pub trait CallConvUtils {
+    fn into_call_conv(self) -> u32;
+}
+
+/// A trait to convert LirUnnamedAddress into LLVM UnnamedAddress.
+///
+/// We need to do this due to the orphan rule in Rust. This could cause the
+/// stop of the compilation process of an external crate.
+pub trait UnnamedAddressUtils {
+    fn into_unnamed_address(&self) -> UnnamedAddress;
+}
+
+impl LinkageUtils for lir::Linkage {
+    fn into_linkage(&self) -> Linkage {
+        match self {
+            lir::Linkage::Private => Linkage::LinkerPrivate,
+            lir::Linkage::Internal => Linkage::Internal,
+            lir::Linkage::AvailableExternally => Linkage::AvailableExternally,
+            lir::Linkage::LinkOnce => Linkage::LinkOnceAny,
+            lir::Linkage::Weak => Linkage::WeakAny,
+            lir::Linkage::Common => Linkage::Common,
+            lir::Linkage::Appending => Linkage::Appending,
+            lir::Linkage::ExternWeak => Linkage::ExternalWeak,
+            lir::Linkage::LinkOnceODR => Linkage::LinkOnceODR,
+            lir::Linkage::WeakODR => Linkage::WeakODR,
+            lir::Linkage::External => Linkage::External,
+        }
+    }
+}
+
+impl VisibilityUtils for lir::Visibility {
+    fn into_visibility(&self) -> GlobalVisibility {
+        match self {
+            lir::Visibility::Default => GlobalVisibility::Default,
+            lir::Visibility::Hidden => GlobalVisibility::Hidden,
+            lir::Visibility::Protected => GlobalVisibility::Protected,
+        }
+    }
+}
+
+impl CallConvUtils for lir::CallConv {
+    fn into_call_conv(self) -> u32 {
+        self as u32
+    }
+}
+
+impl UnnamedAddressUtils for lir::UnnamedAddress {
+    fn into_unnamed_address(&self) -> UnnamedAddress {
+        match self {
+            lir::UnnamedAddress::None => UnnamedAddress::None,
+            lir::UnnamedAddress::Local => UnnamedAddress::Local,
+            lir::UnnamedAddress::Global => UnnamedAddress::Global,
+        }
+    }
+}

--- a/compiler/tidec_codegen_llvm/src/lir/lir_ty.rs
+++ b/compiler/tidec_codegen_llvm/src/lir/lir_ty.rs
@@ -2,6 +2,10 @@ use crate::CodegenCtx;
 use inkwell::types::{BasicMetadataTypeEnum, BasicTypeEnum};
 use tidec_lir::syntax::LirTy;
 
+/// A trait to convert LirTy into LLVM BasicTypeEnum and BasicMetadataTypeEnum.
+///
+/// We need to do this due to the orphan rule in Rust. This could cause the
+/// stop of the compilation process of an external crate.
 pub trait BasicTypesUtils<'ll> {
     fn into_basic_type_metadata(self, ctx: &CodegenCtx<'ll>) -> BasicMetadataTypeEnum<'ll>;
     fn into_basic_type(self, ctx: &CodegenCtx<'ll>) -> BasicTypeEnum<'ll>;

--- a/compiler/tidec_codegen_llvm/src/lir/mod.rs
+++ b/compiler/tidec_codegen_llvm/src/lir/mod.rs
@@ -1,1 +1,2 @@
-pub mod types;
+pub mod lir_body_metadata;
+pub mod lir_ty;

--- a/compiler/tidec_codegen_llvm/src/ssa.rs
+++ b/compiler/tidec_codegen_llvm/src/ssa.rs
@@ -44,7 +44,7 @@ pub trait CodegenBackend: Sized + CodegenBackendTypes {
 }
 
 pub trait PreDefineMethods: Sized + CodegenBackendTypes {
-    fn pre_define(&self, lir_body: &LirBody);
+    fn predefine_fn(&self, lir_body: &LirBody);
 }
 
 /// The codegen backend methods.
@@ -53,7 +53,7 @@ pub trait CodegenMethods<'be>:
 {
     fn new(lir_ty_ctx: LirTyCtx, context: &'be Self::Context, module: Self::Module) -> Self;
     fn get_fn(&self, name: &str) -> Option<Self::Value>;
-    fn new_fn(&self, lir_body: &LirBody) -> Self::Value;
+    fn get_or_declare_fn(&self, lir_body: &LirBody) -> Self::Value;
 }
 
 /// The builder methods for the codegen backend.
@@ -111,7 +111,7 @@ fn compile_lir_body<'a, 'll, B: BuilderMethods<'a, 'll>>(
     ctx: &'a B::CodegenCtx,
     lir_body: LirBody,
 ) {
-    let llfn_value = ctx.new_fn(&lir_body);
+    let llfn_value = ctx.get_or_declare_fn(&lir_body);
     let entry_bb = B::append_basic_block(&ctx, llfn_value, "entry");
     let start_builder = B::build(ctx, entry_bb);
 

--- a/compiler/tidec_codegen_llvm/src/ssa.rs
+++ b/compiler/tidec_codegen_llvm/src/ssa.rs
@@ -1,85 +1,8 @@
-use tidec_abi::TyAndLayout;
-use tidec_lir::lir::{LirBody, LirTyCtx, LirUnit};
-use tidec_lir::syntax::{LirTy, Local, LocalData};
+use tidec_codegen_ssa::traits::{BuilderMethods, CodegenMethods, PreDefineCodegenMethods};
+use tidec_lir::lir::{LirBody, LirUnit};
+use tidec_lir::syntax::{Local, LocalData};
 use tidec_utils::index_vec::IdxVec;
 use tracing::instrument;
-
-// =================
-// ==== Traits =====
-// =================
-
-/// This trait is used to define the types used in the codegen backend.
-/// It is used to define the types used in the codegen backend.
-// FIXME(bruzzone): when `trait alias` is stable, we can use it to alias the `CodegenObject` trait
-// pub trait CodegenObject = Copy + PartialEq + std::fmt::Debug;
-pub trait CodegenBackendTypes {
-    /// A `BasicBlock` is a basic block in the codegen backend.
-    type BasicBlock: Copy + PartialEq + std::fmt::Debug;
-    /// A `Type` is a type in the codegen backend.
-    type Type: Copy + PartialEq + std::fmt::Debug;
-    /// A `Value` is an instance of a type in the codegen backend.
-    /// Note that this should include `FunctionValue`.
-    /// E.g., an instruction, constant, argument, or a function value.
-    type Value: Copy + PartialEq + std::fmt::Debug;
-    /// A `Function` is a function type in the codegen backend.
-    type FunctionType: Copy + PartialEq + std::fmt::Debug;
-    /// A `MetadataType` is a metadata type in the codegen backend.
-    type MetadataType: Copy + PartialEq + std::fmt::Debug;
-    /// A `MetadataValue` is a metadata value in the codegen backend.
-    /// E.g., a debug info node or TBAA (Type-Based Alias Analysis) node.
-    type MetadataValue: Copy + PartialEq + std::fmt::Debug;
-}
-
-/// The codegen backend trait.
-/// It is used to define the methods used in the codegen backend.
-/// The associated types are used to define the types used in the codegen backend.
-pub trait CodegenBackend: Sized + CodegenBackendTypes {
-    /// The associated codegen module type.
-    // FIXME(bruzzone): add constraints to ensure that the module is compatible with the codegen backend.
-    type Module;
-
-    /// The associated codegen context type.
-    // FIXME(bruzzone): add constraints to ensure that the context is compatible with the codegen backend.
-    type Context;
-}
-
-pub trait PreDefineCodegenMethods: Sized + CodegenBackendTypes {
-    fn predefine_fn(&self, lir_body: &LirBody);
-}
-
-/// The codegen backend methods.
-pub trait CodegenMethods<'be>:
-    Sized + CodegenBackendTypes + CodegenBackend + PreDefineCodegenMethods
-{
-    fn new(lir_ty_ctx: LirTyCtx, context: &'be Self::Context, module: Self::Module) -> Self;
-    fn get_fn(&self, lir_body: &LirBody) -> Self::Value;
-}
-
-/// The builder methods for the codegen backend.
-/// This trait is used to define the methods used in the codegen backend.
-pub trait BuilderMethods<'a, 'be>: Sized + CodegenBackendTypes {
-    /// The associated codegen context type.
-    /// This ensures that the codegen context is compatible with the codegen backend types.
-    type CodegenCtx: CodegenMethods<
-        'be,
-        BasicBlock = Self::BasicBlock,
-        Type = Self::Type,
-        Value = Self::Value,
-        FunctionType = Self::FunctionType,
-        MetadataType = Self::MetadataType,
-        MetadataValue = Self::MetadataValue,
-    >;
-
-    fn build(ctx: &'a Self::CodegenCtx, bb: Self::BasicBlock) -> Self;
-
-    fn append_basic_block(
-        ctx: &'a Self::CodegenCtx,
-        fn_value: Self::Value,
-        name: &str,
-    ) -> Self::BasicBlock;
-
-    fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy>;
-}
 
 // =================
 // === Functions ===

--- a/compiler/tidec_codegen_ssa/Cargo.toml
+++ b/compiler/tidec_codegen_ssa/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tidec_codegen_ssa"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# tidy-alphabetical-start
+tidec_abi = { path = "../tidec_abi" }
+tidec_lir = { path = "../tidec_lir" }
+tracing = "0.1.41"
+# tidy-alphabetical-end
+

--- a/compiler/tidec_codegen_ssa/src/lib.rs
+++ b/compiler/tidec_codegen_ssa/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod traits;

--- a/compiler/tidec_codegen_ssa/src/traits.rs
+++ b/compiler/tidec_codegen_ssa/src/traits.rs
@@ -1,0 +1,78 @@
+use tidec_abi::TyAndLayout;
+use tidec_lir::{
+    lir::{LirBody, LirTyCtx},
+    syntax::LirTy,
+};
+
+/// This trait is used to define the types used in the codegen backend.
+/// It is used to define the types used in the codegen backend.
+// FIXME(bruzzone): when `trait alias` is stable, we can use it to alias the `CodegenObject` trait
+// pub trait CodegenObject = Copy + PartialEq + std::fmt::Debug;
+pub trait CodegenBackendTypes {
+    /// A `BasicBlock` is a basic block in the codegen backend.
+    type BasicBlock: Copy + PartialEq + std::fmt::Debug;
+    /// A `Type` is a type in the codegen backend.
+    type Type: Copy + PartialEq + std::fmt::Debug;
+    /// A `Value` is an instance of a type in the codegen backend.
+    /// Note that this should include `FunctionValue`.
+    /// E.g., an instruction, constant, argument, or a function value.
+    type Value: Copy + PartialEq + std::fmt::Debug;
+    /// A `Function` is a function type in the codegen backend.
+    type FunctionType: Copy + PartialEq + std::fmt::Debug;
+    /// A `MetadataType` is a metadata type in the codegen backend.
+    type MetadataType: Copy + PartialEq + std::fmt::Debug;
+    /// A `MetadataValue` is a metadata value in the codegen backend.
+    /// E.g., a debug info node or TBAA (Type-Based Alias Analysis) node.
+    type MetadataValue: Copy + PartialEq + std::fmt::Debug;
+}
+
+/// The codegen backend trait.
+/// It is used to define the methods used in the codegen backend.
+/// The associated types are used to define the types used in the codegen backend.
+pub trait CodegenBackend: Sized + CodegenBackendTypes {
+    /// The associated codegen module type.
+    // FIXME(bruzzone): add constraints to ensure that the module is compatible with the codegen backend.
+    type Module;
+
+    /// The associated codegen context type.
+    // FIXME(bruzzone): add constraints to ensure that the context is compatible with the codegen backend.
+    type Context;
+}
+
+pub trait PreDefineCodegenMethods: Sized + CodegenBackendTypes {
+    fn predefine_fn(&self, lir_body: &LirBody);
+}
+
+/// The codegen backend methods.
+pub trait CodegenMethods<'be>:
+    Sized + CodegenBackendTypes + CodegenBackend + PreDefineCodegenMethods
+{
+    fn new(lir_ty_ctx: LirTyCtx, context: &'be Self::Context, module: Self::Module) -> Self;
+    fn get_fn(&self, lir_body: &LirBody) -> Self::Value;
+}
+
+/// The builder methods for the codegen backend.
+/// This trait is used to define the methods used in the codegen backend.
+pub trait BuilderMethods<'a, 'be>: Sized + CodegenBackendTypes {
+    /// The associated codegen context type.
+    /// This ensures that the codegen context is compatible with the codegen backend types.
+    type CodegenCtx: CodegenMethods<
+            'be,
+            BasicBlock = Self::BasicBlock,
+            Type = Self::Type,
+            Value = Self::Value,
+            FunctionType = Self::FunctionType,
+            MetadataType = Self::MetadataType,
+            MetadataValue = Self::MetadataValue,
+        >;
+
+    fn build(ctx: &'a Self::CodegenCtx, bb: Self::BasicBlock) -> Self;
+
+    fn append_basic_block(
+        ctx: &'a Self::CodegenCtx,
+        fn_value: Self::Value,
+        name: &str,
+    ) -> Self::BasicBlock;
+
+    fn layout_of(&self, ty: LirTy) -> TyAndLayout<LirTy>;
+}

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -6,7 +6,7 @@ use tidec_abi::{CodegenBackend, Target, TyAndLayout};
 use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, instrument};
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Hash, Clone, Copy)]
 pub struct DefId(usize);
 
 /// Specifies the linkage of a symbol.
@@ -217,7 +217,7 @@ pub enum LirBodyKind {
 /// The metadata of a LIR body (function).
 pub struct LirBodyMetadata {
     /// The definition ID of the function.
-    pub id: DefId,
+    pub def_id: DefId,
     /// The name of the function.
     /// It aims to be the `symbol name` for the backend purpose.
     pub name: String,

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -2,7 +2,7 @@ use crate::{
     basic_blocks::{BasicBlock, BasicBlockData},
     syntax::{Body, LirTy, Local, LocalData},
 };
-use tidec_abi::{CodegenBackend, Target, TyAndLayout};
+use tidec_abi::{BackendKind, Target, TyAndLayout};
 use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, instrument};
 
@@ -275,7 +275,7 @@ pub struct LirTyCtx {
 
 impl LirTyCtx {
     #[instrument]
-    pub fn new(codegen_backend: CodegenBackend) -> Self {
+    pub fn new(codegen_backend: BackendKind) -> Self {
         let target = Target::new(codegen_backend);
         let ctx = LirTyCtx { target };
         debug!("LirTyCtx created: {:?}", ctx);

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -108,6 +108,105 @@ pub enum LirItemKind {
     Coroutine,
 }
 
+/// Specifies the significance of a global value's address, used for enabling
+/// optimizations related to constant merging and deduplication.
+///
+/// The `UnnamedAddress` enum is commonly used in compiler internals or
+/// intermediate representations (e.g., LLVM IR) to indicate how the address of
+/// a global variable or constant can be treated by the optimizer.
+///
+/// This information allows the backend to perform optimizations like merging
+/// identical constants or emitting address-independent data.
+pub enum UnnamedAddress {
+    /// The address of the global value is significant and must not be merged
+    /// with others. This is the most conservative option.
+    None,
+    /// The address of the global value is significant only within the current
+    /// translation unit. The optimizer may merge local constants with the same
+    /// content if they are not exposed externally.
+    Local,
+    /// The address is completely insignificant. This allows the optimizer to
+    /// merge identical constants across translation units or even eliminate
+    /// duplicates entirely.
+    Global,
+}
+
+#[derive(Clone, Copy)]
+/// The calling convention of a function.
+///
+/// The calling convention is a low-level detail that specifies how
+/// arguments are passed to a function and how the return value is obtained.
+/// It is important for the backend to know the calling convention in order
+/// to generate the correct code for function calls and returns.
+///
+/// For more details, see the LLVM documentation on calling conventions:
+/// https://llvm.org/docs/LangRef.html#call-conventions
+pub enum CallConv {
+    C = 0,
+    Rust = 1, // Added by Tidec
+    Fast = 8,
+    Cold = 9,
+    GHC = 10,
+    HiPE = 11,
+    AnyReg = 13,
+    PreserveMost = 14,
+    PreserveAll = 15,
+    Swift = 16,
+    CxxFastTls = 17,
+    Tail = 18,
+    CfguardCheck = 19,
+    SwiftTail = 20,
+    PreserveNone = 21,
+    FirstTargetCC = 63, // TODO: In the LLVM documentation it was 64. Overlapping with the X86StdCall
+    X86StdCall = 64,
+    X86FastCall = 65,
+    ArmApcs = 66,
+    ArmAapcs = 67,
+    ArmAapcsVfp = 68,
+    Msp430Intr = 69,
+    X86ThisCall = 70,
+    PtxKernel = 71,
+    PtxDevice = 72,
+    SpirFunc = 75,
+    SpirKernel = 76,
+    IntelOclBi = 77,
+    X86_64SysV = 78,
+    Win64 = 79,
+    X86VectorCall = 80,
+    DummyHhvm = 81,
+    DummyHhvmC = 82,
+    X86Intr = 83,
+    AvrIntr = 84,
+    AvrSignal = 85,
+    AvrBuiltin = 86,
+    AmdgpuVs = 87,
+    AmdgpuGs = 88,
+    AmdgpuPs = 89,
+    AmdgpuCs = 90,
+    AmdgpuKernel = 91,
+    X86RegCall = 92,
+    AmdgpuHs = 93,
+    Msp430Builtin = 94,
+    AmdgpuLs = 95,
+    AmdgpuEs = 96,
+    Aarch64VectorCall = 97,
+    Aarch64SveVectorCall = 98,
+    WasmEmscriptenInvoke = 99,
+    AmdgpuGfx = 100,
+    M68kIntr = 101,
+    Aarch64SmeAbiSupportRoutinesPreserveMostFromX0 = 102,
+    Aarch64SmeAbiSupportRoutinesPreserveMostFromX2 = 103,
+    AmdgpuCsChain = 104,
+    AmdgpuCsChainPreserve = 105,
+    M68kRtd = 106,
+    GRAAL = 107,
+    Arm64ecThunkX64 = 108,
+    Arm64ecThunkNative = 109,
+    RiscvVectorCall = 110,
+    Aarch64SmeAbiSupportRoutinesPreserveMostFromX1 = 111,
+    MaxID = 1023,
+}
+
 /// The kind of a LIR body.
 // TODO(bruzzone): add other kinds of body; e.g. virtual function, fn pointer, etc.
 // See: rustc_middle::ty::InstanceKind
@@ -130,6 +229,10 @@ pub struct LirBodyMetadata {
     pub linkage: Linkage,
     /// The visibility of the function.
     pub visibility: Visibility,
+    /// The unnamed address of the function.
+    pub unnamed_address: UnnamedAddress,
+    /// The calling convention of the function.
+    pub call_conv: CallConv,
 }
 
 /// The body of a function in LIR (Low-level Intermediate Representation).


### PR DESCRIPTION
# Summary

- Add Linkage, Visibility, CallConv, and UnnamedAddr
- Add the preallocation for `fn`s LLVM side
- Modularization: agnostic backend traits in `codegen_ssa` crate